### PR TITLE
Fix Kafka Startup Failure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 services:
   postgres:
     image: postgres


### PR DESCRIPTION
- Upgrade docker compose version from 3 to 3.8.
- Version 3 no longer support  `depends_on` so that's why Kafka was failing each startup time.
- [Stackoverflow](https://stackoverflow.com/questions/47710767/what-is-the-alternative-to-condition-form-of-depends-on-in-docker-compose-versio)
![image](https://github.com/user-attachments/assets/859f0a5c-f8ea-4154-b3ca-eaccbe5b771c)
